### PR TITLE
refactor: split standard and transposed iterators

### DIFF
--- a/src/test/scala/scalarray/ArrayNdBenchmark.scala
+++ b/src/test/scala/scalarray/ArrayNdBenchmark.scala
@@ -1,11 +1,10 @@
 package scalarray
 
 import org.scalameter.api._
-import scala.reflect.ClassTag
 
 object ArrayNdBenchmark extends Bench.ForkedTime {
 
-  private val numElements = Gen.range("elements")(100000, 200000, 20000)
+  private val numElements = Gen.range("elements")(500000, 1000000, 100000)
 
   performance of "java array mapping" in {
     val arrays = numElements.map(n => Array.fill[Int](n)(10))
@@ -25,8 +24,17 @@ object ArrayNdBenchmark extends Bench.ForkedTime {
     }
   }
 
-  performance of "ArrayNd mapping" in {
+  performance of "ArrayNd untransposed mapping" in {
     val arrays = numElements.map(n => ArrayNd.fill[Int](n)(10))
+    measure method "map" in {
+      using(arrays) in { array =>
+        array.map(x => x + x)
+      }
+    }
+  }
+
+  performance of "ArrayNd transposed mapping" in {
+    val arrays = numElements.map(n => ArrayNd.fill[Int](n)(10).reshape(n, 1).transpose)
     measure method "map" in {
       using(arrays) in { array =>
         array.map(x => x + x)


### PR DESCRIPTION
Iteration can happen quicker with standard arrays since elements
can be indexed in order.

They've been defined, for now at least, within `ArrayNdOps` so
that `ArrayNd` fields can be closed over, which appears to offer
a 25% increase in speed.